### PR TITLE
Add functionality for removert

### DIFF
--- a/include/utility.h
+++ b/include/utility.h
@@ -100,6 +100,7 @@ public:
 
     // Save pcd
     bool savePCD;
+    bool saveKeyframePose;
     string savePCDDirectory;
 
     // Lidar Sensor Configuration
@@ -186,6 +187,7 @@ public:
         nh.param<float>("lio_sam/poseCovThreshold", poseCovThreshold, 25.0);
 
         nh.param<bool>("lio_sam/savePCD", savePCD, false);
+        nh.param<bool>("lio_sam/saveKeyframePose", saveKeyframePose, false);
         nh.param<std::string>("lio_sam/savePCDDirectory", savePCDDirectory, "/Downloads/LOAM/");
 
         std::string sensorStr;

--- a/src/mapOptmization.cpp
+++ b/src/mapOptmization.cpp
@@ -197,7 +197,7 @@ public:
 
         // create directory and remove old files
         saveKeyFrameMapDirectory = std::getenv("HOME") + savePCDDirectory + "KeyFramePCDs/";
-        if (saveKeyframePose == true)
+        if (saveKeyframePose)
         {
             saveMapDirectory = std::getenv("HOME") + savePCDDirectory;
             int unused = system((std::string("exec rm -r ") + saveMapDirectory).c_str());
@@ -527,7 +527,7 @@ public:
         }
 
         // save pose graph (runs when programe is closing)
-        if (saveKeyframePose == true)
+        if (saveKeyframePose)
         {
             cout << "****************************************************" << endl;
             cout << "Saving the posegraph ..." << endl;

--- a/src/mapOptmization.cpp
+++ b/src/mapOptmization.cpp
@@ -447,7 +447,7 @@ public:
       else saveMapDirectory = std::getenv("HOME") + req.destination;
       cout << "Save destination: " << saveMapDirectory << endl;
       // create directory and remove old files;
-      if(!saveKeyframePose == true)
+      if(!saveKeyframePose)
       {
         int unused = system((std::string("exec rm -r ") + saveMapDirectory).c_str());
         unused = system((std::string("mkdir -p ") + saveMapDirectory).c_str());
@@ -1694,7 +1694,7 @@ public:
         surfCloudKeyFrames.push_back(thisSurfKeyFrame);
 
         // save keyframe cloud as file
-        if (saveKeyframePose == true)
+        if (saveKeyframePose)
         {
             typename pcl::PointCloud<POINT_TYPE>::Ptr thisSurfKeyFrame_(new pcl::PointCloud<POINT_TYPE>());
             typename pcl::PointCloud<POINT_TYPE>::Ptr thisCornerKeyFrame_(new pcl::PointCloud<POINT_TYPE>());


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
このPRでは以下の機能を実装しています。
- CornerMap.pcd, GlobalMap.pcd, SurfMap.pcd, trajectory.pcd, transformations.pcdのASCIIフォーマットでの保存
- removertを利用するのに必要なoptimized_poses.txtとKeyFramePCDsフォルダの生成

<img src="https://user-images.githubusercontent.com/84959376/218403912-316663b3-c754-4895-a9ec-15bca813c4fe.png" width="300px"><img src="https://user-images.githubusercontent.com/84959376/218403976-c3b1fb9d-4a20-4cd4-8807-87e29aac52b4.png" width="300px">

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
<!--- fix #-->

<!-- 変更の詳細 -->
## Detail
optimized_poses.txtとKeyFramePCDsフォルダを生成する場合には以下の手順を踏んでください。

1. `lio_sam/savePCD`をtrueにする。
2. `lio_sam/saveKeyframePose`をtrueにする。
3. `lio_sam/useRGB`がtrueのときは色情報付きの点群が保存されます。falseのときは色情報を含みません。

launchファイルのサンプルは[こちら](https://github.com/sbgisen/wheeltec_robot/blob/2f161c61a507d4765c59ededd89985d941ea0eb2/wheeltec_create_map/launch/lio_sam_slam.launch)です。
<!-- この関数を変更したのでこの機能にも影響がある、など -->
<!--## Impact-->

<!-- どのような動作検証を行ったか -->
## Test
* [x] つくばチャレンジでのrosbagで動作確認
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した -->

<!--## Attention-->
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
