### PR TITLE
Feature/add voxel filter param

### DIFF
--- a/include/utility.h
+++ b/include/utility.h
@@ -133,7 +133,7 @@ public:
     int surfFeatureMinValidNum;
 
     // voxel filter paprams
-    bool useMappingVoxelFilter;
+    bool downsample;
     float odometrySurfLeafSize;
     float mappingCornerLeafSize;
     float mappingSurfLeafSize ;
@@ -237,7 +237,7 @@ public:
         nh.param<int>("lio_sam/edgeFeatureMinValidNum", edgeFeatureMinValidNum, 10);
         nh.param<int>("lio_sam/surfFeatureMinValidNum", surfFeatureMinValidNum, 100);
 
-        nh.param<bool>("lio_sam/useMappingVoxelFilter", useMappingVoxelFilter, true);
+        nh.param<bool>("lio_sam/downsample", downsample, true);
         nh.param<float>("lio_sam/odometrySurfLeafSize", odometrySurfLeafSize, 0.2);
         nh.param<float>("lio_sam/mappingCornerLeafSize", mappingCornerLeafSize, 0.2);
         nh.param<float>("lio_sam/mappingSurfLeafSize", mappingSurfLeafSize, 0.2);

--- a/include/utility.h
+++ b/include/utility.h
@@ -133,6 +133,7 @@ public:
     int surfFeatureMinValidNum;
 
     // voxel filter paprams
+    bool useMappingVoxelFilter;
     float odometrySurfLeafSize;
     float mappingCornerLeafSize;
     float mappingSurfLeafSize ;
@@ -236,6 +237,7 @@ public:
         nh.param<int>("lio_sam/edgeFeatureMinValidNum", edgeFeatureMinValidNum, 10);
         nh.param<int>("lio_sam/surfFeatureMinValidNum", surfFeatureMinValidNum, 100);
 
+        nh.param<bool>("lio_sam/useMappingVoxelFilter", useMappingVoxelFilter, true);
         nh.param<float>("lio_sam/odometrySurfLeafSize", odometrySurfLeafSize, 0.2);
         nh.param<float>("lio_sam/mappingCornerLeafSize", mappingCornerLeafSize, 0.2);
         nh.param<float>("lio_sam/mappingSurfLeafSize", mappingSurfLeafSize, 0.2);

--- a/src/featureExtraction.cpp
+++ b/src/featureExtraction.cpp
@@ -276,10 +276,16 @@ public:
             }
 
             surfaceCloudScanDS->clear();
-            downSizeFilter.setInputCloud(surfaceCloudScan);
-            downSizeFilter.filter(*surfaceCloudScanDS);
-
-            *surfaceCloud += *surfaceCloudScanDS;
+            if (useMappingVoxelFilter)
+            {
+                downSizeFilter.setInputCloud(surfaceCloudScan);
+                downSizeFilter.filter(*surfaceCloudScanDS);
+                *surfaceCloud += *surfaceCloudScanDS;
+            }
+            else
+            {
+                *surfaceCloud += *surfaceCloudScan;
+            }
         }
     }
 

--- a/src/featureExtraction.cpp
+++ b/src/featureExtraction.cpp
@@ -276,7 +276,7 @@ public:
             }
 
             surfaceCloudScanDS->clear();
-            if (useMappingVoxelFilter)
+            if (downsample)
             {
                 downSizeFilter.setInputCloud(surfaceCloudScan);
                 downSizeFilter.filter(*surfaceCloudScanDS);

--- a/src/mapOptmization.cpp
+++ b/src/mapOptmization.cpp
@@ -91,7 +91,7 @@ public:
     pcl::PointCloud<PointTypePose>::Ptr cloudKeyPoses6D;
     pcl::PointCloud<PointType>::Ptr copy_cloudKeyPoses3D;
     pcl::PointCloud<PointTypePose>::Ptr copy_cloudKeyPoses6D;
-    
+
     pcl::PointCloud<PointType>::Ptr laserCloudCornerLast; // corner feature set from odoOptimization
     pcl::PointCloud<PointType>::Ptr laserCloudSurfLast; // surf feature set from odoOptimization
     pcl::PointCloud<PointType>::Ptr laserCloudCornerLastDS; // downsampled corner feature set from odoOptimization


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
保存するpoint cloudにVoxelGridを使うか否かのパラメータ`useMappingVoxelFilter`を追加しました。
<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #5 

<!-- 変更の詳細 -->
## Detail
環境地図の点群密度に関わってくるVoxelGridを`useMappingVoxelFilter`によって使うか否かを条件分岐します。
- `useMappingVoxelFilter`が`true`のとき
本来のLIO-SAMと同じ処理になります。
- `useMappingVoxelFilter`が`false`のとき
  - 以下のVoxelGridを利用しません。
  https://github.com/sbgisen/LIO-SAM/blob/f698fddf57684edb9a793b85548b2b603119b985/src/featureExtraction.cpp#L280
  - `saveMapService()`に渡すpoint cloudに以下のVoxelGridを適用しないように変数名を変更しています。
  https://github.com/sbgisen/LIO-SAM/blob/f698fddf57684edb9a793b85548b2b603119b985/src/mapOptmization.cpp#L1077
  https://github.com/sbgisen/LIO-SAM/blob/f698fddf57684edb9a793b85548b2b603119b985/src/mapOptmization.cpp#L1082
<!-- この関数を変更したのでこの機能にも影響がある、など -->
<!--## Impact-->

<!-- どのような動作検証を行ったか -->
## Test
* [x] 竹芝でのrosbagで動作確認
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した -->

**実行方法**
- wheeltec_robotのブランチを[fix/lio_sam_args](https://github.com/sbgisen/wheeltec_robot/tree/fix/lio_sam_args)に変更してください。
- 地図を保存する際に、ファイルサイズが大きいためにSIGINTタイムアウトが発生してしまう可能性があります。これを回避するため、`--sigint-timeout`(デフォルトは15)を適宜、設定します。

rosbagから実行する場合
```
roslaunch wheeltec_bringup with_rosbag.launch
roslaunch wheeltec_create_map lio_sam_slam.launch high_density:=true --sigint-timeout=1000
rosbag play yourbag.bag --clock
```
gazeboから実行する場合
```
roslaunch wheeltec_gazebo wheeltec_gazebo.launch world_name:='$(find private_gazebo_worlds)/worlds/tsukuba_start_area.world'
roslaunch wheeltec_create_map lio_sam_slam.launch high_density:=true --sigint-timeout=1000
roslaunch wheeltec_teleop joy_control.launch
```

<!--## Attention-->
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
